### PR TITLE
Load firebase async on pages with kudos

### DIFF
--- a/assets/javascripts/kudos.js
+++ b/assets/javascripts/kudos.js
@@ -1,14 +1,6 @@
-import firebase from 'firebase/app';
-import 'firebase/database';
 import { _ } from './_';
 
-const firebaseApp = firebase.initializeApp({
-  apiKey: 'AIzaSyAggscqrqgt998lEG0qKLUKIpujLtTjZ_s',
-  authDomain: 'shanson-co-31c59.firebaseapp.com',
-  databaseURL: 'https://shanson-co-31c59.firebaseio.com',
-  storageBucket: 'shanson-co-31c59.appspot.com',
-  messagingSenderId: '855737951921',
-});
+let firebaseApp;
 class Kudo {
   constructor(element) {
     this.element = element;
@@ -153,6 +145,40 @@ function storageSupported() {
   return typeof Storage !== 'undefined';
 }
 
-document.querySelectorAll('.kudo-container').forEach((kudoContainer) => {
-  new Kudo(kudoContainer);
+const injectScript = (src, onLoad) => {
+  const script = document.createElement('script');
+  script.type = 'text/javascript';
+  script.defer = true;
+  script.onload = onLoad;
+  script.src = src;
+  document.getElementsByTagName('head')[0].appendChild(script);
+};
+const injectFirebase = (onLoad) => {
+  injectScript('https://www.gstatic.com/firebasejs/8.7.0/firebase-app.js');
+  injectScript(
+    'https://www.gstatic.com/firebasejs/8.7.0/firebase-database.js',
+    onLoad
+  );
+};
+
+const initializeFirebase = () => {
+  firebaseApp = firebase.initializeApp({
+    apiKey: 'AIzaSyAggscqrqgt998lEG0qKLUKIpujLtTjZ_s',
+    authDomain: 'shanson-co-31c59.firebaseapp.com',
+    databaseURL: 'https://shanson-co-31c59.firebaseio.com',
+    storageBucket: 'shanson-co-31c59.appspot.com',
+    messagingSenderId: '855737951921',
+  });
+};
+
+window.addEventListener('load', () => {
+  const kudoContainers = document.querySelectorAll('.kudo-container');
+  if (kudoContainers.length > 0) {
+    injectFirebase(() => {
+      initializeFirebase();
+      for (let container of kudoContainers) {
+        new Kudo(container);
+      }
+    });
+  }
 });

--- a/assets/javascripts/main.js
+++ b/assets/javascripts/main.js
@@ -1,2 +1,3 @@
 import './image-zoom';
 import './lazy-images';
+import './kudos';

--- a/source/layouts/post.erb
+++ b/source/layouts/post.erb
@@ -39,7 +39,4 @@
     </div>
   </section>
 
-  <% content_for :end_of_body do %>
-    <%= javascript_include_tag :kudos, async: true %>
-  <% end %>
 <% end %>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@ const path = require('path');
 module.exports = {
   entry: {
     main: './assets/javascripts/main.js',
-    kudos: './assets/javascripts/kudos.js',
   },
   output: {
     path: path.resolve(__dirname, 'tmp/build'),


### PR DESCRIPTION
This makes it so the large Firebase script doesn't block the `loaded` event. Since the `kudos` script no longer includes Firebase and is now very light, we can include it in the main bundle. Since the main bundle already cached after the homepage, posts now load very quickly.